### PR TITLE
Test/flutter tests

### DIFF
--- a/frontend/lib/features/tickets/widgets/ticket_card.dart
+++ b/frontend/lib/features/tickets/widgets/ticket_card.dart
@@ -25,7 +25,7 @@ class TicketCard extends StatelessWidget {
         borderRadius: BorderRadius.circular(_kBorderRadius),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.1),
+            color: Colors.black.withValues(alpha: 0.1),
             blurRadius: 6,
             offset: const Offset(0, 3),
           ),

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -92,12 +92,3 @@ flutter:
     #
     # For details regarding fonts from package dependencies,
     # see https://flutter.dev/to/font-from-package
-
-flutter_launcher_icons:
-  image_path: "assets/logo.png" 
-  android: true
-  ios: true
-  remove_alpha_ios: true
-  web: 
-    generate: true 
-    favicon_path: "web/favicon.png"

--- a/frontend/test/widget_test.dart
+++ b/frontend/test/widget_test.dart
@@ -1,15 +1,192 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+
 import 'package:aurabus/app.dart';
+import 'package:aurabus/core/providers/app_state.dart';
+import 'package:aurabus/features/account/presentation/account_page.dart';
+import 'package:aurabus/features/tickets/presentation/ticket_page.dart';
+
+void setupMockGoogleMaps() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(
+    const MethodChannel('plugins.flutter.io/google_maps_flutter'),
+    (MethodCall methodCall) async {
+      switch (methodCall.method) {
+        case 'maps#waitForMap':
+        case 'maps#update':
+        case 'camera#animate':
+        case 'markers#update':
+          return null;
+        default:
+          return null;
+      }
+    },
+  );
+}
 
 void main() {
-  testWidgets('App loads successfully smoke test', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      const ProviderScope(
-        child: MyApp(),
-      ),
-    );
-    await tester.pump();
-    expect(find.byType(MyApp), findsOneWidget);
+  setUpAll(() {
+    setupMockGoogleMaps();
+  });
+  group('Loading Tests and Initial State', () {
+    testWidgets(
+        'Show CircularProgressIndicator while providers are loading',
+        (WidgetTester tester) async {
+      final loadingCompleter = Completer<String?>();
+      final markersCompleter = Completer<Set<Marker>>();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            mapStyleProvider.overrideWith((ref) => loadingCompleter.future),
+            markersProvider.overrideWith((ref) => markersCompleter.future),
+          ],
+          child: const MyApp(),
+        ),
+      );
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+      expect(find.byType(GoogleMap), findsNothing);
+    });
+
+    testWidgets('Show GoogleMap when providers load successfully',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            mapStyleProvider.overrideWith((ref) => Future.value('{}')),
+            markersProvider
+                .overrideWith((ref) => Future.value(const <Marker>{})),
+          ],
+          child: const MyApp(),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+
+      expect(find.byType(GoogleMap), findsOneWidget);
+
+      final BottomNavigationBar navBar =
+          tester.widget(find.byType(BottomNavigationBar));
+      expect(navBar.currentIndex, 1);
+    });
+
+    testWidgets('Show error message if a provider fails',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            mapStyleProvider.overrideWith((ref) => Future.value('{}')),
+            markersProvider
+                .overrideWith((ref) => Future.error('Errore di test')),
+          ],
+          child: const MyApp(),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+
+      expect(find.byType(GoogleMap), findsNothing);
+
+      expect(find.textContaining('Loading Error:'), findsOneWidget);
+      expect(find.textContaining('Test Error'), findsOneWidget);
+    });
+  });
+
+  group('Test di Navigazione', () {
+    Future<void> pumpApp(WidgetTester tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            mapStyleProvider.overrideWith((ref) => Future.value('{}')),
+            markersProvider
+                .overrideWith((ref) => Future.value(const <Marker>{})),
+          ],
+          child: const MyApp(),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets(
+        'La navigazione tramite BottomNavigationBar aggiorna la pagina e lo stato della barra',
+        (WidgetTester tester) async {
+      await pumpApp(tester);
+
+      expect(find.byType(GoogleMap), findsOneWidget);
+      expect(
+          tester
+              .widget<BottomNavigationBar>(find.byType(BottomNavigationBar))
+              .currentIndex,
+          1);
+
+      await tester.tap(find.byIcon(Icons.airplane_ticket));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(TicketPage), findsOneWidget);
+      expect(find.text('Your Tickets'), findsOneWidget);
+      expect(find.byType(GoogleMap), findsNothing);
+      expect(
+          tester
+              .widget<BottomNavigationBar>(find.byType(BottomNavigationBar))
+              .currentIndex,
+          0); 
+
+      await tester.tap(find.byIcon(Icons.account_circle));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AccountPage), findsOneWidget);
+      expect(find.text('Account Settings'), findsOneWidget);
+      expect(find.byType(TicketPage), findsNothing);
+      expect(
+          tester
+              .widget<BottomNavigationBar>(find.byType(BottomNavigationBar))
+              .currentIndex,
+          2);
+
+      await tester.tap(find.byIcon(Icons.home));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(GoogleMap), findsOneWidget);
+      expect(find.byType(AccountPage), findsNothing);
+      expect(
+          tester
+              .widget<BottomNavigationBar>(find.byType(BottomNavigationBar))
+              .currentIndex,
+          1);
+    });
+
+    testWidgets('The Sections of the Account Page Expand on Tap',
+        (WidgetTester tester) async {
+      await pumpApp(tester);
+      await tester.tap(find.byIcon(Icons.account_circle));
+      await tester.pumpAndSettle();
+
+      final finderAccountInfo = find.text('Account Info');
+      expect(finderAccountInfo, findsOneWidget);
+
+      expect(find.text('Bus Notifications'), findsNothing);
+
+      await tester.tap(finderAccountInfo);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Bus Notifications'), findsOneWidget);
+
+      await tester.tap(finderAccountInfo);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Bus Notifications'), findsNothing);
+    });
   });
 }

--- a/frontend/test/widget_test.dart
+++ b/frontend/test/widget_test.dart
@@ -1,11 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:aurabus/app.dart';
-
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MyApp(),
+      ),
+    );
 
     expect(find.text('0'), findsOneWidget);
     expect(find.text('1'), findsNothing);

--- a/frontend/test/widget_test.dart
+++ b/frontend/test/widget_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:aurabus/app.dart';

--- a/frontend/test/widget_test.dart
+++ b/frontend/test/widget_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart'; // <-- 1. Aggiungi questo import
 import 'package:aurabus/app.dart';
 
 void main() {
@@ -11,6 +11,7 @@ void main() {
       ),
     );
 
+    await tester.pump();
     expect(find.text('0'), findsOneWidget);
     expect(find.text('1'), findsNothing);
 
@@ -21,3 +22,4 @@ void main() {
     expect(find.text('1'), findsOneWidget);
   });
 }
+

--- a/frontend/test/widget_test.dart
+++ b/frontend/test/widget_test.dart
@@ -4,22 +4,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:aurabus/app.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
+  testWidgets('App loads successfully smoke test', (WidgetTester tester) async {
     await tester.pumpWidget(
       const ProviderScope(
         child: MyApp(),
       ),
     );
-
-    await tester.pumpAndSettle();
-
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pumpAndSettle();
-
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    await tester.pump();
+    expect(find.byType(MyApp), findsOneWidget);
   });
 }

--- a/frontend/test/widget_test.dart
+++ b/frontend/test/widget_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart'; // <-- 1. Aggiungi questo import
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:aurabus/app.dart';
 
 void main() {
@@ -11,15 +11,15 @@ void main() {
       ),
     );
 
-    await tester.pump();
+    await tester.pumpAndSettle();
+
     expect(find.text('0'), findsOneWidget);
     expect(find.text('1'), findsNothing);
 
     await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
+    await tester.pumpAndSettle();
 
     expect(find.text('0'), findsNothing);
     expect(find.text('1'), findsOneWidget);
   });
 }
-

--- a/frontend/test/widget_test.dart
+++ b/frontend/test/widget_test.dart
@@ -108,7 +108,7 @@ void main() {
     });
   });
 
-  group('Test di Navigazione', () {
+  group('Navigation Tests', () {
     Future<void> pumpApp(WidgetTester tester) async {
       await tester.pumpWidget(
         ProviderScope(


### PR DESCRIPTION
This pull request introduces significant improvements to the widget tests for the Flutter frontend, focusing on more robust testing of asynchronous provider loading, navigation, and UI state. Additionally, it removes unused launcher icon configuration from the project and makes a minor update to the ticket card shadow color.

**Testing improvements:**

* Added comprehensive widget tests in `widget_test.dart` to verify provider loading states, error handling, navigation between pages, and UI interactions such as expanding sections in the Account page. This includes mocking Google Maps plugin calls for reliable test execution.

**Project configuration cleanup:**

* Removed the `flutter_launcher_icons` configuration from `pubspec.yaml`, cleaning up unused or unnecessary settings related to app icons and web favicons.

**UI update:**

* Updated the shadow color in the `TicketCard` widget to use `Colors.black.withValues(alpha: 0.1)` for improved color handling.