### PR TITLE
feat: integrate Swagger for API documentation and add new schemas

### DIFF
--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -8,6 +8,7 @@ services:
     volumes:
       - ./src:/app/src
       - ./data:/app/data
+      - ./docs:/app/docs
     depends_on:
       - db
     env_file:

--- a/backend/docs/components/schemas/Error.yaml
+++ b/backend/docs/components/schemas/Error.yaml
@@ -1,0 +1,9 @@
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        error:
+          type: string
+          description: Error message
+          example: "An error occurred."

--- a/backend/docs/components/schemas/StopDetail.yaml
+++ b/backend/docs/components/schemas/StopDetail.yaml
@@ -31,8 +31,10 @@ components:
                 type: string
         stopCode:
           type: string
+          nullable: true
         stopDesc:
           type: string
+          nullable: true
         stopId:
           type: integer
         stopLat:
@@ -47,9 +49,12 @@ components:
           type: string
         street:
           type: string
+          nullable: true
         town:
           type: string
+          nullable: true
         type:
           type: string
+          nullable: true
         wheelchairBoarding:
           type: integer

--- a/backend/docs/components/schemas/StopDetail.yaml
+++ b/backend/docs/components/schemas/StopDetail.yaml
@@ -1,0 +1,55 @@
+components:
+  schemas:
+    StopDetail:
+      type: object
+      properties:
+        distance:
+          type: number
+          nullable: true
+        routes:
+          type: array
+          items:
+            type: object
+            properties:
+              areaId:
+                type: integer
+              news:
+                type: string
+                nullable: true
+              routeColor:
+                type: string
+                nullable: true
+              routeId:
+                type: integer
+              routeLongName:
+                type: string
+              routeShortName:
+                type: string
+              routeType:
+                type: integer
+              type:
+                type: string
+        stopCode:
+          type: string
+        stopDesc:
+          type: string
+        stopId:
+          type: integer
+        stopLat:
+          type: number
+          format: float
+        stopLevel:
+          type: integer
+        stopLon:
+          type: number
+          format: float
+        stopName:
+          type: string
+        street:
+          type: string
+        town:
+          type: string
+        type:
+          type: string
+        wheelchairBoarding:
+          type: integer

--- a/backend/docs/components/schemas/StopTime.yaml
+++ b/backend/docs/components/schemas/StopTime.yaml
@@ -1,0 +1,17 @@
+components:
+  schemas:
+    StopTime:
+      type: object
+      properties:
+        stopId:
+          type: integer
+        stopName:
+          type: string
+        arrivalTimeScheduled:
+          type: string
+          format: time
+          example: "14:35:00"
+        arrivalTimeEstimated:
+          type: string
+          format: time
+          example: "14:36:10"

--- a/backend/docs/components/schemas/TripDetail.yaml
+++ b/backend/docs/components/schemas/TripDetail.yaml
@@ -1,0 +1,36 @@
+components:
+  schemas:
+    TripDetail:
+      type: object
+      properties:
+        routeId:
+          type: integer
+        routeShortName:
+          type: string
+        routeLongName:
+          type: string
+        routeColor:
+          type: string
+          example: "#00A88F"
+          nullable: true
+        busId:
+          type: string
+          description: "Id of the bus"
+        delay:
+          type: integer
+        lastStopId:
+          type: integer
+        nextStopId:
+          type: integer
+        arrivalTimeScheduled:
+          type: string
+          format: time
+          example: "14:30:00"
+        arrivalTimeEstimated:
+          type: string
+          format: time
+          example: "14:32:15"
+        stopTimes:
+          type: array
+          items:
+            $ref: '#/components/schemas/StopTime'

--- a/backend/docs/paths/stops-id.yaml
+++ b/backend/docs/paths/stops-id.yaml
@@ -9,7 +9,7 @@
           name: id
           required: true
           schema:
-            type: integer
+            type: string
           description: The unique ID of the stop to query.
       responses:
         '200':

--- a/backend/docs/paths/stops-id.yaml
+++ b/backend/docs/paths/stops-id.yaml
@@ -1,0 +1,34 @@
+
+  /stops/{id}:
+    get:
+      summary: Retrieves real-time trip updates for a specific stop
+      tags:
+        - Stops
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: The unique ID of the stop to query.
+      responses:
+        '200':
+          description: A list of upcoming trips for the selected stop.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TripDetail'
+        '500':
+          description: Internal server error or error from the external API (invalid data).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '502':
+          description: Bad Gateway. Unable to contact the external API (upstream).
+          content:
+            application/json:
+              schema:
+                $ref: '#components/schemas/Error'

--- a/backend/docs/paths/stops-id.yaml
+++ b/backend/docs/paths/stops-id.yaml
@@ -21,7 +21,7 @@
                 items:
                   $ref: '#/components/schemas/TripDetail'
         '500':
-          description: Internal server error or error from the external API (invalid data).
+          description: Internal server error, or error from the external API due to invalid data (e.g., malformed JSON, missing required fields, or unexpected data types). A 500 error is returned when the external API responds but the data cannot be processed. A 502 error is returned when the external API is unreachable or returns a non-successful HTTP response.
           content:
             application/json:
               schema:
@@ -31,4 +31,4 @@
           content:
             application/json:
               schema:
-                $ref: '#components/schemas/Error'
+                $ref: '#/components/schemas/Error'

--- a/backend/docs/paths/stops.yaml
+++ b/backend/docs/paths/stops.yaml
@@ -1,0 +1,14 @@
+  /stops:
+    get:
+      summary: Return all the stops
+      tags:
+        - Stops
+      responses:
+        '200':
+          description: A list of all the Urban stops available
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/StopDetail'

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,12 +10,76 @@
       "dependencies": {
         "dotenv": "^17.2.3",
         "express": "^5.1.0",
-        "mongoose": "^8.19.3"
+        "mongoose": "^8.19.3",
+        "swagger-jsdoc": "^6.2.8",
+        "swagger-ui-express": "^5.0.1"
       },
       "devDependencies": {
         "jest": "^30.2.0",
         "nodemon": "^3.1.10",
         "supertest": "^7.1.4"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+      "license": "MIT"
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "z-schema": "^5.0.1"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -49,6 +113,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1005,6 +1070,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "license": "MIT"
+    },
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.3.2.tgz",
@@ -1073,6 +1144,13 @@
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.41",
@@ -1183,6 +1261,12 @@
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "24.10.0",
@@ -1708,7 +1792,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
@@ -1758,7 +1841,6 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1798,6 +1880,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -1875,6 +1958,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "license": "MIT"
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -2144,6 +2233,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/component-emitter": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
@@ -2158,7 +2256,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/content-disposition": {
@@ -2309,6 +2406,18 @@
       "dependencies": {
         "asap": "^2.0.0",
         "wrappy": "1"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/dotenv": {
@@ -2482,6 +2591,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -2555,6 +2673,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -2757,7 +2876,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -3089,7 +3207,6 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -4016,6 +4133,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4167,7 +4304,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -4438,6 +4574,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -4542,7 +4685,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5333,6 +5475,83 @@
         "node": ">=4"
       }
     },
+    "node_modules/swagger-jsdoc": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
+      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "6.2.0",
+        "doctrine": "3.0.0",
+        "glob": "7.1.6",
+        "lodash.mergewith": "^4.6.2",
+        "swagger-parser": "^10.0.3",
+        "yaml": "2.0.0-1"
+      },
+      "bin": {
+        "swagger-jsdoc": "bin/swagger-jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/swagger-parser": "10.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.30.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.30.2.tgz",
+      "integrity": "sha512-HWCg1DTNE/Nmapt+0m2EPXFwNKNeKK4PwMjkwveN/zn1cV2Kxi9SURd+m0SpdcSgWEK/O64sf8bzXdtUhigtHA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
     "node_modules/synckit": {
       "version": "0.11.11",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
@@ -5586,6 +5805,15 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/validator": {
+      "version": "13.15.23",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.23.tgz",
+      "integrity": "sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -5775,6 +6003,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/yaml": {
+      "version": "2.0.0-1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -5860,6 +6097,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/z-schema": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      },
+      "bin": {
+        "z-schema": "bin/z-schema"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "commander": "^9.4.1"
+      }
+    },
+    "node_modules/z-schema/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     }
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,9 @@
   "dependencies": {
     "dotenv": "^17.2.3",
     "express": "^5.1.0",
-    "mongoose": "^8.19.3"
+    "mongoose": "^8.19.3",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "jest": "^30.2.0",

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -2,8 +2,11 @@ import express from "express";
 import { connect } from "mongoose";
 import config from "./config.js";
 import { stops, routes } from "./data.js";
+import { setupSwagger } from "./swagger.js";
 
 export const app = express();
+
+setupSwagger(app);
 
 const header = {
   method: "GET",
@@ -45,7 +48,7 @@ app.get("/stops", (req, res) => {
   res.json(Array.from(stops.values()));
 });
 
-app.get("/stop/:id", async (req, res) => {
+app.get("/stops/:id", async (req, res) => {
   const stopId = req.params.id;
   try {
     const result = await fetch(
@@ -70,6 +73,7 @@ app.get("/stop/:id", async (req, res) => {
         routeLongName: route.routeLongName,
         routeColor: route.routeColor,
         busId: element.matricolaBus,
+        delay: element.delay,
         lastStopId: element.stopLast,
         nextStopId: element.stopNext,
         arrivalTimeScheduled: element.oraArrivoProgrammataAFermataSelezionata,
@@ -78,8 +82,8 @@ app.get("/stop/:id", async (req, res) => {
           ? element.stopTimes.map((st) => ({
               stopId: st.stopId,
               stopName: stops.get(st.stopId)?.stopName || "Unknown",
-              arrivalTimeScheduled: st.oraArrivoProgrammataAFermata,
-              arrivalTimeEstimated: st.oraArrivoEffettivaAFermata,
+              arrivalTimeScheduled: st.arrivalTime,
+              arrivalTimeEstimated: st.departureTime,
             }))
           : [],
       });

--- a/backend/src/config.js
+++ b/backend/src/config.js
@@ -10,6 +10,7 @@ const config = {
   },
   api: {
     port: process.env.API_PORT || 8888,
+    baseUrl: process.env.API_BASE_URL || "http://localhost",
   },
   db: {
     user: process.env.MONGO_USER,

--- a/backend/src/swagger.js
+++ b/backend/src/swagger.js
@@ -1,0 +1,38 @@
+import swaggerJsdoc from "swagger-jsdoc";
+import swaggerUi from "swagger-ui-express";
+import path from "path";
+import { fileURLToPath } from "url";
+import config from "./config.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const port = config.api.port;
+
+const options = {
+  definition: {
+    openapi: "3.0.3",
+    info: {
+      title: "AuraBus API",
+      version: "1.0.0",
+      description: "API for tracking bus status in real time",
+    },
+    servers: [
+      {
+        url: `http://localhost:${port}`,
+        description: "Development Server",
+      },
+    ],
+  },
+  apis: [
+    path.join(__dirname, "../docs/paths/*.yaml"),
+    path.join(__dirname, "../docs/components/schemas/*.yaml"),
+  ],
+};
+
+const specs = swaggerJsdoc(options);
+
+export function setupSwagger(app) {
+  app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(specs));
+  console.log("Documentation Swagger UI available on /api-docs");
+}

--- a/backend/src/swagger.js
+++ b/backend/src/swagger.js
@@ -8,6 +8,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const port = config.api.port;
+const baseUrl = config.api.baseUrl;
 
 const options = {
   definition: {
@@ -19,7 +20,7 @@ const options = {
     },
     servers: [
       {
-        url: `http://localhost:${port}`,
+        url: `${baseUrl}:${port}`,
         description: "Development Server",
       },
     ],
@@ -32,6 +33,9 @@ const options = {
 
 const specs = swaggerJsdoc(options);
 
+/**
+ * * @param {object} app
+ */
 export function setupSwagger(app) {
   app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(specs));
   console.log("Documentation Swagger UI available on /api-docs");

--- a/backend/src/swagger.js
+++ b/backend/src/swagger.js
@@ -34,7 +34,7 @@ const options = {
 const specs = swaggerJsdoc(options);
 
 /**
- * * @param {object} app
+ * @param {object} app
  */
 export function setupSwagger(app) {
   app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(specs));

--- a/backend/tests/app.test.js
+++ b/backend/tests/app.test.js
@@ -37,3 +37,116 @@ describe('API Endpoints', () => {
     expect(sortByStopId(response.body)).toEqual(sortByStopId(expectedStops));
   });
 });
+
+describe("GET /stops/:id (Trip Details)", () => {
+  let fetchSpy;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetchSpy = jest.spyOn(global, "fetch");
+  });
+
+  it("should return 200 and transformed trips on success", async () => {
+    const mockApiData = [
+      {
+        routeId: "R1",
+        matricolaBus: "B123",
+        delay: 0,
+        stopLast: "S1",
+        stopNext: "S3",
+        oraArrivoProgrammataAFermataSelezionata: "10:00:00",
+        oraArrivoEffettivaAFermataSelezionata: "10:00:15",
+        stopTimes: [
+          { stopId: "S1", arrivalTime: "09:55:00", departureTime: "09:55:10" },
+          { stopId: "S2", arrivalTime: "10:00:00", departureTime: "10:00:15" },
+        ],
+      },
+    ];
+
+    const mockRoute = {
+      routeId: "R1",
+      routeShortName: "10",
+      routeLongName: "Centro - Sobborgo",
+      routeColor: "blue",
+    };
+    
+    const mockStopTime1 = { stopName: "Fermata 1" };
+    const mockStopTime2 = { stopName: "Fermata 2" };
+
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue(mockApiData),
+    });
+    routes.get.mockReturnValue(mockRoute);
+    stops.get.mockImplementation((stopId) => {
+      if (stopId === "S1") return mockStopTime1;
+      if (stopId === "S2") return mockStopTime2;
+      return { stopName: "Unknown" };
+    });
+
+    const res = await request(app).get("/stops/S2");
+
+    expect(res.statusCode).toBe(200);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("stopId=S2"),
+      expect.any(Object)
+    );
+    expect(routes.get).toHaveBeenCalledWith("R1");
+    expect(stops.get).toHaveBeenCalledWith("S1");
+    expect(stops.get).toHaveBeenCalledWith("S2");
+    
+    expect(res.body).toEqual([
+      {
+        routeId: "R1",
+        routeShortName: "10",
+        routeLongName: "Centro - Sobborgo",
+        routeColor: "blue",
+        busId: "B123",
+        delay: 0,
+        lastStopId: "S1",
+        nextStopId: "S3",
+        arrivalTimeScheduled: "10:00:00",
+        arrivalTimeEstimated: "10:00:15",
+        stopTimes: [
+          { stopId: "S1", stopName: "Fermata 1", arrivalTimeScheduled: "09:55:00", arrivalTimeEstimated: "09:55:10" },
+          { stopId: "S2", stopName: "Fermata 2", arrivalTimeScheduled: "10:00:00", arrivalTimeEstimated: "10:00:15" },
+        ],
+      },
+    ]);
+  });
+
+  it("should return 502 if external API fetch fails", async () => {
+    fetchSpy.mockResolvedValue({
+      ok: false,
+      status: 503,
+      statusText: "Service Down",
+    });
+
+    const res = await request(app).get("/stops/qualunque-id");
+
+    expect(res.statusCode).toBe(502);
+    expect(res.body).toEqual({
+      error: "Failed to fetch data from external API: 503 Service Down",
+    });
+  });
+
+  it("should return 500 if external API returns an application error", async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({ error: "Invalid API Key" }),
+    });
+
+    const res = await request(app).get("/stops/id-valido");
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ error: "Invalid API Key" });
+  });
+  
+  it("should return 502 if fetch throws a network error", async () => {
+    fetchSpy.mockRejectedValue(new Error("Network connection failed"));
+
+    const res = await request(app).get("/stops/id-valido");
+
+    expect(res.statusCode).toBe(502);
+    expect(res.body).toEqual({ error: "Failed to fetch or process data from external API." });
+  });
+});

--- a/backend/tests/app.test.js
+++ b/backend/tests/app.test.js
@@ -1,11 +1,9 @@
+import { jest } from "@jest/globals";
 import request from "supertest";
 import mongoose from "mongoose";
-import { app, connectDb } from "../src/app.js";
 import expectedStops from "../data/stops.json" with { type: "json" };
-import { initData, stops, routes } from "../src/data.js";
-import { jest } from "@jest/globals";
 
-jest.mock("../src/data.js", () => ({
+await jest.unstable_mockModule("../src/data.js", () => ({
   initData: jest.fn(),
   stops: {
     get: jest.fn(),
@@ -15,6 +13,9 @@ jest.mock("../src/data.js", () => ({
     get: jest.fn(),
   },
 }));
+
+const { app, connectDb } = await import("../src/app.js");
+const { initData, stops, routes } = await import("../src/data.js");
 
 describe("API Endpoints", () => {
   beforeAll(async () => {

--- a/backend/tests/app.test.js
+++ b/backend/tests/app.test.js
@@ -3,6 +3,7 @@ import mongoose from 'mongoose';
 import { app, connectDb } from '../src/app.js';
 import expectedStops from '../data/stops.json' with { type: 'json' };
 import { initData } from '../src/data.js';
+import { jest } from "@jest/globals";
 
 describe('API Endpoints', () => {
   


### PR DESCRIPTION
This pull request adds OpenAPI/Swagger documentation support for the backend, including schemas and endpoint definitions for stops and trips, and updates the Docker and dependency configuration to support these changes.

**API Documentation and Schemas**

* Added OpenAPI schemas for `Error`, `StopDetail`, `StopTime`, and `TripDetail` in the `backend/docs/components/schemas` directory, describing the structure of stop, trip, and error responses. [[1]](diffhunk://#diff-5b623ca8ca0195ae27350e1fca7618db122acce38ed85ce8872ffd161d7faa5aR1-R9) [[2]](diffhunk://#diff-ddd66f2d23b4a84dd7b7a99855b8f5e2dd8dd15786a1610c071cb294fa39d036R1-R55) [[3]](diffhunk://#diff-299632369f1c511ed76496bee4f24a131bacc8b937e093c217636a6a0d6feef5R1-R17) [[4]](diffhunk://#diff-63e9596da62f691206d470b189d5879c47cdd5fe63fc02a9b84fbc3499a05127R1-R36)
* Defined new API endpoints in OpenAPI format: `/stops` for retrieving all stops and `/stops/{id}` for getting real-time trip updates for a specific stop, including response types and error handling. [[1]](diffhunk://#diff-ffa0800c108c623ac92bac13c5a04cf157ad294573d38ecb5f5edabdb5eddd48R1-R14) [[2]](diffhunk://#diff-8bee33b749cca3281334b2f10f206042fa6f8c105f7ce32d506a1ee776ff38d0R1-R34)

**Dependency and Configuration Updates**

* Added Swagger-related dependencies (`swagger-jsdoc`, `swagger-ui-express`, and supporting packages) to `backend/package-lock.json` to enable API documentation generation and UI. ([backend/package-lock.jsonL13-R84](diffhunk://#diff-f89763fc11c1bc48ac3c7ce8a148fbbbc5c2062393ee78664a70273d714daf5cL13-R84) and related package additions)
* Mounted the `docs` directory into the backend Docker container to make documentation available at runtime.